### PR TITLE
All mines now are revealed upon game over

### DIFF
--- a/src/ts/reveal.ts
+++ b/src/ts/reveal.ts
@@ -79,6 +79,12 @@ function revealCell(row: number, col: number) {
         const gameover = document.getElementById('gameover');
         gameover != null ? gameover.style.visibility = 'visible' : null;
 
+        const tiles = document.getElementsByClassName('grid-tile');
+        for (const tile of tiles) {
+            const {row, col} = getCellCoordinates(tile as HTMLElement)
+            const tileValue = minefield[row]![col]!;
+            tileValue === 1 ? tile.textContent = "💣": null;
+        }
 
         return;
     }


### PR DESCRIPTION
As title says, all mines should now be revealed when the game over screen is triggered. We might want to consider pulling the function out of the game over, in case we would also like to reveal them all on victory to confirm, though it might be redundant.